### PR TITLE
Bump version to 2025.1.5 and update changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and the versioning follows CalVer.
 
+## 2025.1.5 (Patch) - 2025-09-25
+### Changed
+- Updated version to 2025.1.5.
+
+## 2025.1.5 - 2025-09-05
+### Changed
+- Align project with updated GitHub Copilot instructions.
+
 ## 2025.1.4 - 2025-09-05
 ### Changed
 - Align project with updated Cursor rules; added detailed research and plan docs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "splurge-dsv"
-version = "2025.1.4"
+version = "2025.1.5"
 description = "A utility library for working with DSV (Delimited String Values) files"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/splurge_dsv/__init__.py
+++ b/splurge_dsv/__init__.py
@@ -44,7 +44,7 @@ from splurge_dsv.resource_manager import (
 from splurge_dsv.string_tokenizer import StringTokenizer
 from splurge_dsv.text_file_helper import TextFileHelper
 
-__version__ = "2025.1.4"
+__version__ = "2025.1.5"
 __author__ = "Jim Schilling"
 __license__ = "MIT"
 


### PR DESCRIPTION
This pull request updates the project version from `2025.1.4` to `2025.1.5` across all relevant files and documents a new patch release in the changelog. No functional code changes are included.

Version bump and documentation:

* Updated the project version to `2025.1.5` in `pyproject.toml` and `splurge_dsv/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-0012e8d65853853aefa1dc67296c7148ce2eb8c94d143317b48ace3d5d692680L47-R47)
* Added a new entry for version `2025.1.5 (Patch)` in `CHANGELOG.md`.