### PR TITLE
feat: Deprecate `parse_stream` API in favor of `parse_file_stream` an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and the versioning follows CalVer.
 
-## 2025.2.0 - (Release Date TBD)
+## 2025.2.1 - 2025-10-07
+### Deprecated
+- **Deprecated `parse_stream` API**: `Dsv.parse_stream()` and `DsvHelper.parse_stream()` now emit a deprecation warning and will be removed in a future release. Use the new `parse_file_stream()` method on `Dsv`/`DsvHelper` instead for stream-based parsing of files (preserves chunked/streaming behavior). This change was made to standardize the naming and make the streaming API surface consistent across helpers and the `Dsv` class.
+
+
+## 2025.2.0 - 2025-10-06
 ### Added
 - **Comprehensive Property-Based Testing**: Added Hypothesis framework tests for invariant verification
   - `test_string_tokenizer_properties.py`: 6 tests covering parsing consistency and edge cases

--- a/docs/README-details.md
+++ b/docs/README-details.md
@@ -1,5 +1,12 @@
 # splurge-dsv — Detailed Documentation
 
+> **⚠️ DEPRECATION WARNING in v2025.2.1**
+>
+> - **DsvHelper.parse_stream**: This method is deprecated in favor of `DsvHelper.parse_file_stream`.
+> - **Dsv.parse_stream**: This method is deprecated in favor of `Dsv.parse_file_stream`.
+>
+> See the [CHANGELOG](CHANGELOG.md) for migration guidance.
+
 > **⚠️ BREAKING CHANGES in v2025.2.0**
 >
 > - **Exception Names Changed**: All exceptions now use `SplurgeDsv*` prefix (e.g., `SplurgeParameterError` → `SplurgeDsvParameterError`)
@@ -137,12 +144,12 @@ rows = DsvHelper.parse_file(
 from splurge_dsv import DsvHelper
 
 # Stream parse a large file in chunks
-for chunk in DsvHelper.parse_stream("large_file.csv", delimiter=",", chunk_size=1000):
+for chunk in DsvHelper.parse_file_stream("large_file.csv", delimiter=",", chunk_size=1000):
     for row in chunk:
         process_row(row)
 
 # Stream with header/footer skipping
-for chunk in DsvHelper.parse_stream(
+for chunk in DsvHelper.parse_file_stream(
     "large_file.csv",
     delimiter=",",
     skip_header_rows=1,
@@ -245,7 +252,7 @@ Modern object-oriented API class that encapsulates configuration and provides pa
 - `parse(content)` - Parse a single string
 - `parses(content_list)` - Parse multiple strings
 - `parse_file(file_path)` - Parse a file
-- `parse_stream(file_path)` - Stream parse a file
+- `parse_file_stream(file_path)` - Stream parse a file
 
 ### DsvHelper
 
@@ -256,7 +263,7 @@ Main class for DSV parsing operations.
 - `parse(content, delimiter, strip=True, bookend=None, bookend_strip=True)` - Parse a single string
 - `parses(content_list, delimiter, strip=True, bookend=None, bookend_strip=True)` - Parse multiple strings
 - `parse_file(file_path, delimiter, strip=True, bookend=None, bookend_strip=True, skip_header_rows=0, skip_footer_rows=0, encoding='utf-8')` - Parse a file
-- `parse_stream(file_path, delimiter, strip=True, bookend=None, bookend_strip=True, skip_header_rows=0, skip_footer_rows=0, encoding='utf-8', chunk_size=500)` - Stream parse a file
+- `parse_file_stream(file_path, delimiter, strip=True, bookend=None, bookend_strip=True, skip_header_rows=0, skip_footer_rows=0, encoding='utf-8', chunk_size=500)` - Stream parse a file
 
 ### TextFileHelper
 
@@ -324,7 +331,7 @@ rows = dsv.parses(["a,b,c", "d,e,f"])
 rows = dsv.parse_file("data.csv")
 
 # Stream parse large files
-for chunk in dsv.parse_stream("large.csv"):
+for chunk in dsv.parse_file_stream("large.csv"):
     for row in chunk:
         process_row(row)
 ```
@@ -484,7 +491,7 @@ from splurge_dsv import DsvHelper
 # For very large files, use streaming with small chunks
 def process_large_file(file_path):
     total_rows = 0
-    for chunk in DsvHelper.parse_stream(file_path, delimiter=",", chunk_size=100):
+    for chunk in DsvHelper.parse_file_stream(file_path, delimiter=",", chunk_size=100):
         for row in chunk:
             total_rows += 1
             # Process row immediately to save memory

--- a/docs/api/API-REFERENCE.md
+++ b/docs/api/API-REFERENCE.md
@@ -94,7 +94,10 @@ Error modes:
 
 `Dsv` is a small, stateful wrapper around the parsing helpers. You typically
 instantiate a `Dsv` with a `DsvConfig` and call `parse`, `parse_file`, or
-`parse_stream`.
+`parse_file_stream`.
+
+> Note: `parse_stream()` remains available for backward compatibility but is
+> deprecated and will emit a DeprecationWarning; prefer `parse_file_stream()`.
 
 API surface (abridged):
 
@@ -103,6 +106,12 @@ API surface (abridged):
 - `parse_file(path: str, ...) -> list[list[str]]` — Parse an entire file.
 - `parse_stream(path: str, ...) -> Iterator[list[list[str]]]` — Stream-parse a
   file in chunks.
+ - `parse_file_stream(path: str, ...) -> Iterator[list[list[str]]]` — Preferred stream-parse method; yields parsed chunks and aligns naming with `parse_file()`.
+
+> Deprecated: `parse_stream()` is deprecated. Use `parse_file_stream()` instead.
+> `parse_stream()` will emit a DeprecationWarning when called and will be
+> removed in a future release. See `parse_file_stream()` below for the
+> preferred API.
 
 Example — parse a file with headers:
 
@@ -130,14 +139,20 @@ Key methods:
 - `DsvHelper.parse(content: str, *, delimiter: str, bookend: str|None = None, strip: bool=True) -> list[str]`
 - `DsvHelper.parses(content: list[str], *, delimiter: str, ...) -> list[list[str]]`
 - `DsvHelper.parse_file(file_path: str, *, delimiter: str, encoding: str='utf-8', ...) -> list[list[str]]`
-- `DsvHelper.parse_stream(file_path: str, *, delimiter: str, chunk_size: int=500, ...) -> Iterator[list[list[str]]]`
+ - `DsvHelper.parse_stream(file_path: str, *, delimiter: str, chunk_size: int=500, ...) -> Iterator[list[list[str]]]`
+   
+   Deprecated: `DsvHelper.parse_stream()` will emit a DeprecationWarning and
+   delegates to `DsvHelper.parse_file_stream()`. Use `parse_file_stream()` for
+   a clearer name and consistent error handling across the API.
+
+ - `DsvHelper.parse_file_stream(file_path: str, *, delimiter: str, chunk_size: int=500, ...) -> Iterator[list[list[str]]]` — Preferred streaming API. Yields parsed chunks of rows read from the file. Parameters and behavior match `parse_stream()` but with a clearer name that aligns with `parse_file()`.
 
 Example — parse streaming file in chunks:
 
 ```python
 from splurge_dsv import DsvHelper
 
-for chunk in DsvHelper.parse_stream("big.csv", delimiter=","):
+for chunk in DsvHelper.parse_file_stream("big.csv", delimiter=","):
     for row in chunk:
         process(row)
 ```
@@ -335,7 +350,7 @@ rows = parser.parse_file("data.csv")
 ```python
 from splurge_dsv import DsvHelper
 
-for chunk in DsvHelper.parse_stream("big.csv", delimiter=","):
+for chunk in DsvHelper.parse_file_stream("big.csv", delimiter=","):
     for row in chunk:
         # process row
         pass

--- a/docs/notes/migration-parse-stream-to-parse-file-stream-2025-10-07.md
+++ b/docs/notes/migration-parse-stream-to-parse-file-stream-2025-10-07.md
@@ -1,0 +1,60 @@
+# Migration: `parse_stream` -> `parse_file_stream` (2025-10-07)
+
+As of release 2025.2.1 the `parse_stream()` method is deprecated in favor of
+`parse_file_stream()`. The runtime behavior is unchanged — both methods yield
+parsed chunks of rows — but the new name better aligns with `parse_file()` and
+clarifies that the operation reads from files.
+
+Why the change
+- Standardizes API naming across file-based operations (`parse_file`,
+  `parse_file_stream`).
+- Improves discoverability and clarity for new users.
+
+Compatibility
+- `parse_stream()` will continue to work for a short deprecation window but will
+  emit a `DeprecationWarning` when called. Please update usage to avoid
+  breakage when the method is removed in a future release.
+
+How to migrate
+
+Old usage (deprecated):
+
+```python
+from splurge_dsv import DsvHelper
+
+for chunk in DsvHelper.parse_stream("big.csv", delimiter=","):
+    for row in chunk:
+        process(row)
+```
+
+New usage (preferred):
+
+```python
+from splurge_dsv import DsvHelper
+
+for chunk in DsvHelper.parse_file_stream("big.csv", delimiter=","):
+    for row in chunk:
+        process(row)
+```
+
+If you use the object-oriented API:
+
+```python
+from splurge_dsv import Dsv, DsvConfig
+
+cfg = DsvConfig.csv()
+parser = Dsv(cfg)
+
+# Deprecated
+for chunk in parser.parse_stream("big.csv"):
+    ...
+
+# Preferred
+for chunk in parser.parse_file_stream("big.csv"):
+    ...
+```
+
+Notes
+- The CLI `--stream` option is unchanged; this migration concerns the Python API.
+- If you rely on `DeprecationWarning`s being visible in test runs, configure
+  pytest (or other test runners) to show them (e.g., `pytest -W default`).

--- a/examples/modern_api_example.py
+++ b/examples/modern_api_example.py
@@ -145,7 +145,7 @@ def demonstrate_file_operations() -> None:
         print("\n--- Streaming Example ---")
         chunk_count = 0
         total_rows = 0
-        for chunk in csv_dsv.parse_stream(str(csv_file)):
+        for chunk in csv_dsv.parse_file_stream(str(csv_file)):
             chunk_count += 1
             total_rows += len(chunk)
             print(f"✓ Processed chunk {chunk_count}: {len(chunk)} rows")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "splurge-dsv"
-version = "2025.2.0"
+version = "2025.2.1"
 description = "A utility library for working with DSV (Delimited String Values) files"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/splurge_dsv/__init__.py
+++ b/splurge_dsv/__init__.py
@@ -60,7 +60,7 @@ from splurge_dsv.path_validator import PathValidator
 from splurge_dsv.string_tokenizer import StringTokenizer
 from splurge_dsv.text_file_helper import TextFileHelper
 
-__version__ = "2025.2.0"
+__version__ = "2025.2.1"
 __author__ = "Jim Schilling"
 __license__ = "MIT"
 

--- a/splurge_dsv/cli.py
+++ b/splurge_dsv/cli.py
@@ -161,7 +161,7 @@ def run_cli() -> int:
             chunk_count = 0
             total_rows = 0
 
-            for chunk in dsv.parse_stream(file_path):
+            for chunk in dsv.parse_file_stream(file_path):
                 chunk_count += 1
                 total_rows += len(chunk)
                 if args.output_format == "json":

--- a/splurge_dsv/dsv.py
+++ b/splurge_dsv/dsv.py
@@ -17,6 +17,7 @@ Copyright (c) 2025 Jim Schilling
 """
 
 # Standard library imports
+import warnings
 from collections.abc import Iterator
 from dataclasses import dataclass, fields
 from os import PathLike
@@ -230,7 +231,7 @@ class Dsv:
             skip_footer_rows=self.config.skip_footer_rows,
         )
 
-    def parse_stream(self, file_path: PathLike[str] | str) -> Iterator[list[list[str]]]:
+    def parse_file_stream(self, file_path: PathLike[str] | str) -> Iterator[list[list[str]]]:
         """Stream-parse a DSV file, yielding chunks of parsed rows.
 
         The method yields lists of parsed rows (each row itself is a list of
@@ -243,7 +244,7 @@ class Dsv:
         Yields:
             Lists of parsed rows, each list containing up to ``chunk_size`` rows.
         """
-        return DsvHelper.parse_stream(
+        return DsvHelper.parse_file_stream(
             file_path,
             delimiter=self.config.delimiter,
             strip=self.config.strip,
@@ -254,3 +255,26 @@ class Dsv:
             skip_footer_rows=self.config.skip_footer_rows,
             chunk_size=self.config.chunk_size,
         )
+
+    def parse_stream(self, file_path: PathLike[str] | str) -> Iterator[list[list[str]]]:
+        """Stream-parse a DSV file, yielding chunks of parsed rows.
+
+        The method yields lists of parsed rows (each row itself is a list of
+        strings). Chunk sizing is controlled by the bound configuration's
+        ``chunk_size`` value.
+
+        Args:
+            file_path: Path to the file to parse.
+
+        Yields:
+            Lists of parsed rows, each list containing up to ``chunk_size`` rows.
+
+        Deprecated: Use `parse_file_stream` instead. This method will be removed in a future release.
+        """
+        # Emit a DeprecationWarning to signal removal in a future release
+        warnings.warn(
+            "Dsv.parse_stream() is deprecated and will be removed in a future release; use Dsv.parse_file_stream() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Dsv.parse_file_stream(self, file_path)

--- a/splurge_dsv/dsv_helper.py
+++ b/splurge_dsv/dsv_helper.py
@@ -9,6 +9,7 @@ This module is licensed under the MIT License.
 """
 
 # Standard library imports
+import warnings
 from collections.abc import Iterator
 from os import PathLike
 
@@ -199,7 +200,7 @@ class DsvHelper:
         return cls.parses(chunk, delimiter=delimiter, strip=strip, bookend=bookend, bookend_strip=bookend_strip)
 
     @classmethod
-    def parse_stream(
+    def parse_file_stream(
         cls,
         file_path: PathLike[str] | str,
         *,
@@ -213,7 +214,7 @@ class DsvHelper:
         chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> Iterator[list[list[str]]]:
         """
-        Stream-parse a DSV file in chunks of lines.
+        Stream-parse a DSV file into chunks of lines.
 
         Args:
             file_path (PathLike[str] | str): The path to the file to parse.
@@ -254,4 +255,52 @@ class DsvHelper:
                 skip_footer_rows=skip_footer_rows,
                 chunk_size=chunk_size,
             )
+        )
+
+    @classmethod
+    def parse_stream(
+        cls,
+        file_path: PathLike[str] | str,
+        *,
+        delimiter: str,
+        strip: bool = DEFAULT_STRIP,
+        bookend: str | None = None,
+        bookend_strip: bool = DEFAULT_BOOKEND_STRIP,
+        encoding: str = DEFAULT_ENCODING,
+        skip_header_rows: int = DEFAULT_SKIP_HEADER_ROWS,
+        skip_footer_rows: int = DEFAULT_SKIP_FOOTER_ROWS,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ) -> Iterator[list[list[str]]]:
+        """
+        Stream-parse a DSV file, yielding chunks of parsed rows.
+
+        The method yields lists of parsed rows (each row itself is a list of
+        strings). Chunk sizing is controlled by the bound configuration's
+        ``chunk_size`` value.
+
+        Args:
+            file_path: Path to the file to parse.
+
+        Yields:
+            Lists of parsed rows, each list containing up to ``chunk_size`` rows.
+
+        Deprecated: Use `parse_file_stream` instead. This method will be removed in a future release.
+        """
+        # Emit a DeprecationWarning to signal removal in a future release
+        warnings.warn(
+            "DsvHelper.parse_stream() is deprecated and will be removed in a future release; use DsvHelper.parse_file_stream() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return cls.parse_file_stream(
+            file_path,
+            delimiter=delimiter,
+            strip=strip,
+            bookend=bookend,
+            bookend_strip=bookend_strip,
+            encoding=encoding,
+            skip_header_rows=skip_header_rows,
+            skip_footer_rows=skip_footer_rows,
+            chunk_size=chunk_size,
         )

--- a/tests/integration/test_file_operations.py
+++ b/tests/integration/test_file_operations.py
@@ -140,7 +140,7 @@ class TestFileStreamingIntegration:
         test_file = tmp_path / "empty.csv"
         test_file.write_text("")
 
-        result = list(DsvHelper.parse_stream(test_file, delimiter=","))
+        result = list(DsvHelper.parse_file_stream(test_file, delimiter=","))
         assert result == []
 
     def test_parse_stream_basic_csv(self, tmp_path: Path) -> None:
@@ -148,7 +148,7 @@ class TestFileStreamingIntegration:
         test_file = tmp_path / "test.csv"
         test_file.write_text("a,b,c\nd,e,f\ng,h,i")
 
-        result = list(DsvHelper.parse_stream(test_file, delimiter=","))
+        result = list(DsvHelper.parse_file_stream(test_file, delimiter=","))
         expected = [[["a", "b", "c"], ["d", "e", "f"], ["g", "h", "i"]]]
         assert result == expected
 
@@ -157,7 +157,7 @@ class TestFileStreamingIntegration:
         test_file = tmp_path / "test.csv"
         test_file.write_text('"a","b","c"\n"d","e","f"')
 
-        result = list(DsvHelper.parse_stream(test_file, delimiter=",", bookend='"'))
+        result = list(DsvHelper.parse_file_stream(test_file, delimiter=",", bookend='"'))
         expected = [[["a", "b", "c"], ["d", "e", "f"]]]
         assert result == expected
 
@@ -166,7 +166,7 @@ class TestFileStreamingIntegration:
         test_file = tmp_path / "test.csv"
         test_file.write_text("header1,header2,header3\na,b,c\nd,e,f")
 
-        result = list(DsvHelper.parse_stream(test_file, delimiter=",", skip_header_rows=1))
+        result = list(DsvHelper.parse_file_stream(test_file, delimiter=",", skip_header_rows=1))
         expected = [[["a", "b", "c"], ["d", "e", "f"]]]
         assert result == expected
 
@@ -175,7 +175,7 @@ class TestFileStreamingIntegration:
         test_file = tmp_path / "nonexistent.csv"
 
         with pytest.raises(SplurgeDsvFileNotFoundError):
-            list(DsvHelper.parse_stream(test_file, delimiter=","))
+            list(DsvHelper.parse_file_stream(test_file, delimiter=","))
 
 
 class TestFileEncodingIntegration:
@@ -265,7 +265,7 @@ class TestLargeFileIntegration:
         test_file.write_text("\n".join(lines))
 
         # Stream the file
-        result = list(DsvHelper.parse_stream(test_file, delimiter=","))
+        result = list(DsvHelper.parse_file_stream(test_file, delimiter=","))
 
         # The result is a list of chunks, each chunk contains multiple rows
         # With default chunk size, we might get multiple chunks

--- a/tests/unit/test_dsv.py
+++ b/tests/unit/test_dsv.py
@@ -285,7 +285,7 @@ class TestDsv:
             temp_path = f.name
 
         try:
-            chunks = list(parser.parse_stream(temp_path))
+            chunks = list(parser.parse_file_stream(temp_path))
             # Should have at least one chunk
             assert len(chunks) >= 1
             # All chunks should be non-empty
@@ -308,9 +308,9 @@ class TestDsv:
             temp_path = f.name
 
         try:
-            dsv_chunks = list(parser.parse_stream(temp_path))
+            dsv_chunks = list(parser.parse_file_stream(temp_path))
             helper_chunks = list(
-                DsvHelper.parse_stream(
+                DsvHelper.parse_file_stream(
                     temp_path,
                     delimiter="\t",
                     chunk_size=3,

--- a/tests/unit/test_parse_stream_deprecation.py
+++ b/tests/unit/test_parse_stream_deprecation.py
@@ -1,0 +1,30 @@
+import pytest
+
+from splurge_dsv.dsv import Dsv, DsvConfig
+from splurge_dsv.dsv_helper import DsvHelper
+
+
+def _stub_parse_file_stream(*args, **kwargs):
+    # Return a simple iterator to avoid touching the filesystem during the test
+    yield ["a", "b", "c"]
+
+
+def test_dsvhelper_parse_stream_emits_deprecation(monkeypatch):
+    monkeypatch.setattr(DsvHelper, "parse_file_stream", _stub_parse_file_stream)
+
+    with pytest.warns(DeprecationWarning):
+        chunks = list(DsvHelper.parse_stream("dummy.csv", delimiter=","))
+
+    assert chunks == [["a", "b", "c"]]
+
+
+def test_dsv_parse_stream_emits_deprecation(monkeypatch):
+    monkeypatch.setattr(DsvHelper, "parse_file_stream", _stub_parse_file_stream)
+
+    cfg = DsvConfig.csv()
+    parser = Dsv(cfg)
+
+    with pytest.warns(DeprecationWarning):
+        chunks = list(parser.parse_stream("dummy.csv"))
+
+    assert chunks == [["a", "b", "c"]]


### PR DESCRIPTION
This pull request deprecates the `parse_stream` API in favor of a new, consistently named `parse_file_stream` method across both the `Dsv` class and `DsvHelper`. The change standardizes the streaming API surface, improves naming clarity, and updates all documentation and tests to use the new method. Calls to the deprecated `parse_stream` methods now emit a `DeprecationWarning` and delegate to `parse_file_stream`. Migration notes and guidance are provided for users.

**API Deprecation and Migration:**

* Deprecated `Dsv.parse_stream()` and `DsvHelper.parse_stream()` methods; they now emit a `DeprecationWarning` and delegate to the new `parse_file_stream()` method. (`splurge_dsv/dsv.py`, `splurge_dsv/dsv_helper.py`) [[1]](diffhunk://#diff-4f14975a4e0739d83862066569651a96eeecc0e7209e4f40e0cfc47cab8fd3cfR258-R280) [[2]](diffhunk://#diff-710bce816253639748693e61edd9b1e0c0ff5e0d6d404f6c167976e34681b408R259-R306)
* Added migration documentation and guidance for updating usage from `parse_stream` to `parse_file_stream`. (`docs/notes/migration-parse-stream-to-parse-file-stream-2025-10-07.md`)
* Updated changelog to document the deprecation and the new preferred API. (`CHANGELOG.md`)

**Documentation Updates:**

* Revised all API references, guides, and code examples to use `parse_file_stream` instead of `parse_stream`, with clear deprecation notes. (`docs/README-details.md`, `docs/api/API-REFERENCE.md`) [[1]](diffhunk://#diff-41361067134e81254892ed81daf5003ef7efccb920e5b6b14a11674bb01fa430L140-R152) [[2]](diffhunk://#diff-cc7930a0b3f33e0d638ac3e0cae7c5c4ff2f515896df46a07721607850e0b96bR144-R155)

**Code and Test Updates:**

* Updated all usages of `parse_stream` in the CLI, examples, and integration tests to use `parse_file_stream`. (`splurge_dsv/cli.py`, `examples/modern_api_example.py`, `tests/integration/test_file_operations.py`) [[1]](diffhunk://#diff-1640795be32cacbebabc8149441d02a889424bd22afe184120e16fb880236234L164-R164) [[2]](diffhunk://#diff-49021079a31cbf4ec0729b6a8b6f641054d8ccc486fbd58a184ddc22210b1bd2L148-R148) [[3]](diffhunk://#diff-e85ce22932aa7d0a15002a3dcef13ece4112371a15c9ea367e3dbe8807dc9ca0L143-R151)

**Version Bump:**

* Bumped project version to `2025.2.1` to reflect the API change. (`pyproject.toml`, `splurge_dsv/__init__.py`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-0012e8d65853853aefa1dc67296c7148ce2eb8c94d143317b48ace3d5d692680L63-R63)